### PR TITLE
[Delete] 役割が薄れたので開発者ツイッターリンクを削除．

### DIFF
--- a/src/lists.adoc
+++ b/src/lists.adoc
@@ -30,15 +30,6 @@ IRCチャンネルに「#ぐりっどばぐ」(UTF-8)があります。Discord�
 
 Discordサーバ link:https://discord.gg/8xW6q5SqXY[#ぐりっどばぐ] へどうぞ。
 
-### 現在活動を行なっている開発者のTwitter
-
-意見や要望など直接に送れば、一番早く対応が来るかも知れません。以下HNアルファベット順敬称略。
-
-* link:https://twitter.com/deskull[deskull]
-* link:https://twitter.com/dis_[dis-]
-* link:https://twitter.com/habu1010[habu]
-* link:https://twitter.com/hiromi_yuh[Hourier]
-
 ### Twitterの関連bot
 
 * link:https://twitter.com/hengband_speak[変愚セリフbot]


### PR DESCRIPTION
Discordで総意もらいましたのでまず開発者リンク削除します。