### PR TITLE
[Fix] RSSのリンクをmarsに変更

### DIFF
--- a/src/scorelinks.html
+++ b/src/scorelinks.html
@@ -6,7 +6,7 @@
 			</p>
 
 			<div class="scorelinks">
-				<a href="/score/feed/newcome-atom.xml" class="button">
+				<a href="http://mars.kmc.gr.jp/~dis/heng_score/feed/newcome-atom.xml" class="button">
 					<img src="/image/feed-icon-128x128.png">
 					<span>RSS</span>
 				</a>


### PR DESCRIPTION
RSSのリンク先がローカルになっていて正常に機能していないので、スコアサーバーの実体へのリンクに修正する。