### PR TITLE
[Feature] ヘッダー・フッターの共通化

### DIFF
--- a/src/footer.html
+++ b/src/footer.html
@@ -2,14 +2,11 @@
 
 			<section>
 				各ページへのリンクは御自由にどうぞ。/ Link Free.<br>
-				2021 Hengband Dev Team. <a href="mailto:hengband-dev@lists.sourceforge.jp">hengband-dev@lists.sourceforge.jp</a><br>
+				2000-2023 Hengband Dev Team. <a href="mailto:hengband-dev@lists.sourceforge.jp">hengband-dev@lists.sourceforge.jp</a><br>
 			</section>
 
 			<section>
-				Powered by <a href="https://osdn.net/" class="footer_banner">
-				<img src="//osdn.net/sflogo.php?group_id=541" border="0" alt="OSDN">
-				</a>
+				Sorry, English documentation is under construction.
 			</section>
 
 		</footer>
-

--- a/src/header.html
+++ b/src/header.html
@@ -21,7 +21,7 @@
 				<a href="/history.html">バージョン履歴</a>
 				<a href="/link.html">関連リンク</a>
 				<a href="/jlicense.html">著作権表記</a>
-				<span>English (Coming Soon?)</span>
+				<!--<span>English (Coming Soon?)</span>-->
 			</section>
 
 		</header>


### PR DESCRIPTION
#171 のIssueへのプルリクエストです。

ヘッダーから`English (Coming Soon?)`をコメントアウト。
2021→2023、「powerd by osdn」を削除。`Sorry, English documentation is under construction.`を追加。
この適用でメールアドレスの有無以外は、hengband.ioのものと同じになります。

▼devtoolsで現在のページのhtmlを直接書き換えて、疑似的にこの変更を適用した様子です。
![スクリーンショット 2023-05-13 224235](https://github.com/hengband/web/assets/108442898/b8664fad-0a4a-404b-9bac-4f2db1b24db4)
